### PR TITLE
Add common check helper in tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,11 +83,23 @@
               home.stateVersion = "24.11";
             };
           };
-          testScript = ''
-            start_all
-            machine.wait_for_unit("default.target");
-            machine.succeed("su - alice -c 'tmux -V'");
-          '';
+          testScript =
+            let
+              tmuxConf = "/home/alice/.tmux.conf";
+              check = line:
+                "machine.succeed(\"grep -q '^${line}$' ${tmuxConf}\")";
+            in
+            ''
+              start_all
+              machine.wait_for_unit("default.target");
+              machine.succeed("su - alice -c 'tmux -V'");
+              ${check "set-option -g prefix C-a"}
+              ${check "bind-key h select-pane -L"}
+              ${check "bind-key l select-pane -R"}
+              ${check "bind-key j select-pane -U"}
+              ${check "bind-key k select-pane -D"}
+              ${check "display-message \"Hello, tmux-nix!\""}
+            '';
         };
 
         treefmt = {


### PR DESCRIPTION
## Summary
- use a let expression to share tmuxConf and a `check` helper in the integration test
- verify prefix, pane keymaps, and extra config using the helper

## Testing
- `nix flake check --no-build --impure` *(fails: Could not connect to server)*
- `nix fmt` *(fails: Could not connect to server)*