### PR TITLE
Add binding-level repeatable keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,8 @@
 - When modifying the tmux integration test in `flake.nix`, define a reusable `check` helper using a `let` expression.
 - Use this helper to verify expected lines in `.tmux.conf` with `grep -q '^${line}$'`.
 - Ensure keymaps, prefix, and `extraConfig` lines are covered.
+
+## Implementation Heuristics
+- Configure each key binding with `key` and `repeatable` attributes under the binding name (e.g. `keymaps.pane.left.key`).
+- Keep integration tests minimal: verify non-repeatable bindings via `left` and `right`, and repeatable bindings via `up` and `down`.
+- Append any new decisions or rules identified during implementation to this file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,18 @@
 # Coding Guidelines
 
 ## Commit Author
+
 - All commits must be authored as `Codex <codex@openai.com>`.
 - Each commit message must include the line `Co-authored-by: Mutsuha Asada <me@momee.mt>`.
 
 ## Tests
+
 - When modifying the tmux integration test in `flake.nix`, define a reusable `check` helper using a `let` expression.
 - Use this helper to verify expected lines in `.tmux.conf` with `grep -q '^${line}$'`.
 - Ensure keymaps, prefix, and `extraConfig` lines are covered.
 
 ## Implementation Heuristics
+
 - Configure each key binding with `key` and `repeatable` attributes under the binding name (e.g. `keymaps.pane.left.key`).
 - Keep integration tests minimal: verify non-repeatable bindings via `left` and `right`, and repeatable bindings via `up` and `down`.
 - Append any new decisions or rules identified during implementation to this file.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # tmux-nix
+
 Configure tmux with Nix

--- a/flake.nix
+++ b/flake.nix
@@ -70,10 +70,10 @@
                 prefix = "C-a";
                 keymaps = {
                   pane = {
-                    left = "h";
-                    right = "l";
-                    up = "j";
-                    down = "k";
+                    left.key = "h";
+                    right.key = "l";
+                    up = { key = "j"; repeatable = true; };
+                    down = { key = "k"; repeatable = true; };
                   };
                 };
                 extraConfig = ''
@@ -93,8 +93,8 @@
             ${check "set-option -g prefix C-a"}
             ${check "bind-key h select-pane -L"}
             ${check "bind-key l select-pane -R"}
-            ${check "bind-key j select-pane -U"}
-            ${check "bind-key k select-pane -D"}
+            ${check "bind-key -r j select-pane -U"}
+            ${check "bind-key -r k select-pane -D"}
             ${check "display-message \"Hello, tmux-nix!\""}
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -72,8 +72,14 @@
                   pane = {
                     left.key = "h";
                     right.key = "l";
-                    up = { key = "j"; repeatable = true; };
-                    down = { key = "k"; repeatable = true; };
+                    up = {
+                      key = "j";
+                      repeatable = true;
+                    };
+                    down = {
+                      key = "k";
+                      repeatable = true;
+                    };
                   };
                 };
                 extraConfig = ''
@@ -103,6 +109,7 @@
           projectRootFile = "flake.nix";
           programs = {
             alejandra.enable = true;
+            mdformat.enable = true;
           };
           settings.global.excludes = [
             "LICENSE-*"

--- a/modules/tmux-nix.nix
+++ b/modules/tmux-nix.nix
@@ -44,10 +44,22 @@
             in
               lib.types.submodule {
                 options = {
-                  left = lib.mkOption { type = bindingType; default = {}; };
-                  right = lib.mkOption { type = bindingType; default = {}; };
-                  up = lib.mkOption { type = bindingType; default = {}; };
-                  down = lib.mkOption { type = bindingType; default = {}; };
+                  left = lib.mkOption {
+                    type = bindingType;
+                    default = {};
+                  };
+                  right = lib.mkOption {
+                    type = bindingType;
+                    default = {};
+                  };
+                  up = lib.mkOption {
+                    type = bindingType;
+                    default = {};
+                  };
+                  down = lib.mkOption {
+                    type = bindingType;
+                    default = {};
+                  };
                 };
               };
           };
@@ -59,8 +71,14 @@
         pane = {
           left.key = "h";
           right.key = "l";
-          up = { key = "j"; repeatable = true; };
-          down = { key = "k"; repeatable = true; };
+          up = {
+            key = "j";
+            repeatable = true;
+          };
+          down = {
+            key = "k";
+            repeatable = true;
+          };
         };
       };
     };
@@ -78,8 +96,7 @@
     home.packages = [config.tmux-nix.package];
     home.file.".tmux.conf".text = let
       tmux-nix = config.tmux-nix;
-      bind-key = binding: cmd:
-        "bind-key${lib.optionalString binding.repeatable " -r"} ${binding.key} ${cmd}";
+      bind-key = binding: cmd: "bind-key${lib.optionalString binding.repeatable " -r"} ${binding.key} ${cmd}";
       maybe-bind-key = binding: cmd:
         lib.optionalString (binding.key != null) (bind-key binding cmd);
     in ''

--- a/modules/tmux-nix.nix
+++ b/modules/tmux-nix.nix
@@ -28,17 +28,26 @@
             description = "Pane movement key bindings";
             default = {};
             type = let
-              common = lib.mkOption {
-                type = lib.types.nullOr lib.types.str;
-                default = null;
+              bindingType = lib.types.submodule {
+                options = {
+                  key = lib.mkOption {
+                    type = lib.types.nullOr lib.types.str;
+                    default = null;
+                  };
+                  repeatable = lib.mkOption {
+                    type = lib.types.bool;
+                    default = false;
+                    description = "Whether to pass -r to bind-key.";
+                  };
+                };
               };
             in
               lib.types.submodule {
                 options = {
-                  left = common;
-                  right = common;
-                  up = common;
-                  down = common;
+                  left = lib.mkOption { type = bindingType; default = {}; };
+                  right = lib.mkOption { type = bindingType; default = {}; };
+                  up = lib.mkOption { type = bindingType; default = {}; };
+                  down = lib.mkOption { type = bindingType; default = {}; };
                 };
               };
           };
@@ -48,10 +57,10 @@
       description = "Keymaps to use for tmux";
       example = {
         pane = {
-          left = "h";
-          right = "l";
-          up = "j";
-          down = "k";
+          left.key = "h";
+          right.key = "l";
+          up = { key = "j"; repeatable = true; };
+          down = { key = "k"; repeatable = true; };
         };
       };
     };
@@ -69,8 +78,10 @@
     home.packages = [config.tmux-nix.package];
     home.file.".tmux.conf".text = let
       tmux-nix = config.tmux-nix;
-      bind-key = key: cmd: "bind-key ${key} ${cmd}";
-      maybe-bind-key = key: cmd: lib.optionalString (key != null) (bind-key key cmd);
+      bind-key = binding: cmd:
+        "bind-key${lib.optionalString binding.repeatable " -r"} ${binding.key} ${cmd}";
+      maybe-bind-key = binding: cmd:
+        lib.optionalString (binding.key != null) (bind-key binding cmd);
     in ''
       set-option -g prefix ${tmux-nix.prefix}
 


### PR DESCRIPTION
## Summary
- refine implementation notes in `AGENTS.md`
- support `repeatable` flag per tmux key binding
- simplify integration tests for repeatable bindings

## Testing
- `nix run .#treefmt` *(fails: Could not connect to server)*
- `nix flake check` *(fails: Could not connect to server)*