### PR TITLE
Add per-binding resize amounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,6 @@
 - Configure each key binding with `key` and `repeatable` attributes under the binding name (e.g. `keymaps.pane.left.key`).
 - Keep integration tests minimal: verify non-repeatable bindings via `left` and `right`, and repeatable bindings via `up` and `down`.
 - Append any new decisions or rules identified during implementation to this file.
+
+- Each `keymaps.resize.*` binding includes an `amount` option (default 5). Tests must verify these values with the existing `check` helper.
+- README should list options with a sample configuration and avoid explaining tmux commands like `resize-pane`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,11 @@
 ## Implementation Heuristics
 
 - Configure each key binding with `key` and `repeatable` attributes under the binding name (e.g. `keymaps.pane.left.key`).
+
 - Keep integration tests minimal: verify non-repeatable bindings via `left` and `right`, and repeatable bindings via `up` and `down`.
+
 - Append any new decisions or rules identified during implementation to this file.
 
 - Each `keymaps.resize.*` binding includes an `amount` option (default 5). Tests must verify these values with the existing `check` helper.
+
 - README should list options with a sample configuration and avoid explaining tmux commands like `resize-pane`.

--- a/README.md
+++ b/README.md
@@ -32,4 +32,3 @@ Example configuration:
   };
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # tmux-nix
 
-Configure tmux with Nix
+Configure tmux with Nix.
+
+## Options
+
+- `tmux-nix.enable` (bool): enable configuration.
+- `tmux-nix.package` (package): tmux package to install.
+- `tmux-nix.prefix` (string): prefix key.
+- `tmux-nix.keymaps.pane.*`: pane movement key bindings.
+- `tmux-nix.keymaps.resize.*`: pane resizing bindings; each binding has an `amount` attribute.
+- `tmux-nix.extraConfig` (lines): additional configuration appended to `.tmux.conf`.
+
+Example configuration:
+
+```nix
+{
+  tmux-nix = {
+    enable = true;
+    keymaps.resize.left.amount = 10;
+    keymaps.resize.right.amount = 10;
+    keymaps.resize.up = {
+      key = "J";
+      repeatable = true;
+      amount = 10;
+    };
+    keymaps.resize.down = {
+      key = "K";
+      repeatable = true;
+      amount = 10;
+    };
+  };
+}
+```
+

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,26 @@
                       repeatable = true;
                     };
                   };
+                  resize = {
+                    left = {
+                      key = "H";
+                      amount = 10;
+                    };
+                    right = {
+                      key = "L";
+                      amount = 10;
+                    };
+                    up = {
+                      key = "J";
+                      repeatable = true;
+                      amount = 10;
+                    };
+                    down = {
+                      key = "K";
+                      repeatable = true;
+                      amount = 10;
+                    };
+                  };
                 };
                 extraConfig = ''
                   display-message "Hello, tmux-nix!"
@@ -101,6 +121,10 @@
             ${check "bind-key l select-pane -R"}
             ${check "bind-key -r j select-pane -U"}
             ${check "bind-key -r k select-pane -D"}
+            ${check "bind-key H resize-pane -L 10"}
+            ${check "bind-key L resize-pane -R 10"}
+            ${check "bind-key -r J resize-pane -U 10"}
+            ${check "bind-key -r K resize-pane -D 10"}
             ${check "display-message \"Hello, tmux-nix!\""}
           '';
         };

--- a/modules/tmux-nix.nix
+++ b/modules/tmux-nix.nix
@@ -23,45 +23,65 @@
     };
     keymaps = lib.mkOption {
       type = lib.types.submodule {
-        options = {
+        options = let
+          baseBindingType = lib.types.submodule {
+            options = {
+              key = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+              };
+              repeatable = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Whether to pass -r to bind-key.";
+              };
+            };
+          };
+          bindingType = baseBindingType;
+          resizeBindingType = lib.types.submodule {
+            options = {
+              key = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+              };
+              repeatable = lib.mkOption {
+                type = lib.types.bool;
+                default = false;
+                description = "Whether to pass -r to bind-key.";
+              };
+              amount = lib.mkOption {
+                type = lib.types.int;
+                default = 5;
+                description = "Number of cells to adjust when resizing.";
+              };
+            };
+          };
+          bindingGroup = lib.types.submodule {
+            options = {
+              left = lib.mkOption { type = bindingType; default = {}; };
+              right = lib.mkOption { type = bindingType; default = {}; };
+              up = lib.mkOption { type = bindingType; default = {}; };
+              down = lib.mkOption { type = bindingType; default = {}; };
+            };
+          };
+          resizeGroup = lib.types.submodule {
+            options = {
+              left = lib.mkOption { type = resizeBindingType; default = {}; };
+              right = lib.mkOption { type = resizeBindingType; default = {}; };
+              up = lib.mkOption { type = resizeBindingType; default = {}; };
+              down = lib.mkOption { type = resizeBindingType; default = {}; };
+            };
+          };
+        in {
           pane = lib.mkOption {
             description = "Pane movement key bindings";
             default = {};
-            type = let
-              bindingType = lib.types.submodule {
-                options = {
-                  key = lib.mkOption {
-                    type = lib.types.nullOr lib.types.str;
-                    default = null;
-                  };
-                  repeatable = lib.mkOption {
-                    type = lib.types.bool;
-                    default = false;
-                    description = "Whether to pass -r to bind-key.";
-                  };
-                };
-              };
-            in
-              lib.types.submodule {
-                options = {
-                  left = lib.mkOption {
-                    type = bindingType;
-                    default = {};
-                  };
-                  right = lib.mkOption {
-                    type = bindingType;
-                    default = {};
-                  };
-                  up = lib.mkOption {
-                    type = bindingType;
-                    default = {};
-                  };
-                  down = lib.mkOption {
-                    type = bindingType;
-                    default = {};
-                  };
-                };
-              };
+            type = bindingGroup;
+          };
+          resize = lib.mkOption {
+            description = "Pane resizing key bindings";
+            default = {};
+            type = resizeGroup;
           };
         };
       };
@@ -78,6 +98,26 @@
           down = {
             key = "k";
             repeatable = true;
+          };
+        };
+        resize = {
+          left = {
+            key = "H";
+            amount = 10;
+          };
+          right = {
+            key = "L";
+            amount = 10;
+          };
+          up = {
+            key = "J";
+            repeatable = true;
+            amount = 10;
+          };
+          down = {
+            key = "K";
+            repeatable = true;
+            amount = 10;
           };
         };
       };
@@ -107,6 +147,12 @@
       ${maybe-bind-key tmux-nix.keymaps.pane.right "select-pane -R"}
       ${maybe-bind-key tmux-nix.keymaps.pane.up "select-pane -U"}
       ${maybe-bind-key tmux-nix.keymaps.pane.down "select-pane -D"}
+
+      # -- pane resizing --
+      ${maybe-bind-key tmux-nix.keymaps.resize.left "resize-pane -L ${toString tmux-nix.keymaps.resize.left.amount}"}
+      ${maybe-bind-key tmux-nix.keymaps.resize.right "resize-pane -R ${toString tmux-nix.keymaps.resize.right.amount}"}
+      ${maybe-bind-key tmux-nix.keymaps.resize.up "resize-pane -U ${toString tmux-nix.keymaps.resize.up.amount}"}
+      ${maybe-bind-key tmux-nix.keymaps.resize.down "resize-pane -D ${toString tmux-nix.keymaps.resize.down.amount}"}
 
       ${tmux-nix.extraConfig}
     '';

--- a/modules/tmux-nix.nix
+++ b/modules/tmux-nix.nix
@@ -58,18 +58,42 @@
           };
           bindingGroup = lib.types.submodule {
             options = {
-              left = lib.mkOption { type = bindingType; default = {}; };
-              right = lib.mkOption { type = bindingType; default = {}; };
-              up = lib.mkOption { type = bindingType; default = {}; };
-              down = lib.mkOption { type = bindingType; default = {}; };
+              left = lib.mkOption {
+                type = bindingType;
+                default = {};
+              };
+              right = lib.mkOption {
+                type = bindingType;
+                default = {};
+              };
+              up = lib.mkOption {
+                type = bindingType;
+                default = {};
+              };
+              down = lib.mkOption {
+                type = bindingType;
+                default = {};
+              };
             };
           };
           resizeGroup = lib.types.submodule {
             options = {
-              left = lib.mkOption { type = resizeBindingType; default = {}; };
-              right = lib.mkOption { type = resizeBindingType; default = {}; };
-              up = lib.mkOption { type = resizeBindingType; default = {}; };
-              down = lib.mkOption { type = resizeBindingType; default = {}; };
+              left = lib.mkOption {
+                type = resizeBindingType;
+                default = {};
+              };
+              right = lib.mkOption {
+                type = resizeBindingType;
+                default = {};
+              };
+              up = lib.mkOption {
+                type = resizeBindingType;
+                default = {};
+              };
+              down = lib.mkOption {
+                type = resizeBindingType;
+                default = {};
+              };
             };
           };
         in {


### PR DESCRIPTION
## Summary
- allow per-binding resize amounts
- show sample config in README and drop resize-pane description
- update integration test
- document rule about README in AGENTS

## Testing
- `nix fmt .` *(failed: Could not connect to server)*
- `nix run .#treefmt` *(failed: Could not connect to server)*
- `nix flake check --no-build --print-build-logs` *(failed: Could not connect to server)*